### PR TITLE
Use master branch of ContributionScores

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -775,7 +775,7 @@
 [submodule "extensions/ContributionScores"]
 	path = extensions/ContributionScores
 	url = https://github.com/wikimedia/mediawiki-extensions-ContributionScores
-	branch = REL1_34
+	branch = master
 	ignore = dirty
 [submodule "extensions/TocTree"]
 	path = extensions/TocTree


### PR DESCRIPTION
Following https://gerrit.wikimedia.org/r/#/q/Ia395f904d12d96e0d8bf0c1b2a5f638639b3ab12

This patches the currently running ContributionScores version which isn't working at all.