### PR TITLE
Set rc_patrolled field to 2 (autopatrolled actions)

### DIFF
--- a/maintenance/rebuildrecentchanges.php
+++ b/maintenance/rebuildrecentchanges.php
@@ -470,7 +470,7 @@ class RebuildRecentchanges extends Maintenance {
 						$cond,
 						'rc_timestamp > ' . $dbw->addQuotes( $dbw->timestamp( $this->cutoffFrom ) ),
 						'rc_timestamp < ' . $dbw->addQuotes( $dbw->timestamp( $this->cutoffTo ) ),
-						'rc_patrolled' => 0
+						'rc_patrolled' => 2
 					];
 
 					if ( !$wgUseRCPatrol ) {


### PR DESCRIPTION
Related to Phabricator ticket https://phabricator.miraheze.org/T6392 (see also https://phabricator.miraheze.org/T5939, https://phabricator.miraheze.org/T5940, and https://phabricator.miraheze.org/T5943) whereby when this script is run, it marks all revisions of former administrators as unpatrolled. It arguably makes much more sense to mark all revisions as patrolled, rather than unpatrolled