### PR TITLE
Updating DynamicPageList3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1406,7 +1406,10 @@
 	path = extensions/MediaModeration
 	url = https://github.com/wikimedia/mediawiki-extensions-MediaModeration
 	branch = REL1_35
+	ignore = dirty
 [submodule "extensions/DynamicPageList3"]
 	path = extensions/DynamicPageList3
 	url = https://github.com/Universal-Omega/DynamicPageList3.git
 	branch = REL1_35
+	ignore = dirty
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -587,11 +587,6 @@
 	url = https://github.com/labster/HideSection.git
 	branch = master
 	ignore = dirty
-[submodule "extensions/DynamicPageList3"]
-	path = extensions/DynamicPageList3
-	url = https://gitlab.com/hydrawiki/extensions/DynamicPageList.git
-	branch = master
-	ignore = dirty
 [submodule "extensions/WikiTextLoggedInOut"]
 	path = extensions/WikiTextLoggedInOut
 	url = https://github.com/wikimedia/mediawiki-extensions-WikiTextLoggedInOut
@@ -1410,4 +1405,8 @@
 [submodule "extensions/MediaModeration"]
 	path = extensions/MediaModeration
 	url = https://github.com/wikimedia/mediawiki-extensions-MediaModeration
+	branch = REL1_35
+[submodule "extensions/DynamicPageList3"]
+	path = extensions/DynamicPageList3
+	url = https://github.com/Universal-Omega/DynamicPageList3.git
 	branch = REL1_35


### PR DESCRIPTION
Done, because currently the original DynamicPageList3 is completely broken upstream. I fixed this in my fork, to which as long as necessary, I plan to maintain. I have also submitted the merge request upstream, but there are outstanding requests over a year old, therefore it is better to, in the meantime, at least deploy the working version for Miraheze. 