### PR TITLE
Dependabot: Switch to REL1_36

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     interval: weekly
     time: "00:00"
   open-pull-requests-limit: 250
-  target-branch: REL1_35
+  target-branch: REL1_36


### PR DESCRIPTION
Miraheze now has a 1.36 branch, we should update that. After this point, no more updates to REL1_35 will be done automatically.