### PR TITLE
Change branch from master to main for Citizen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1196,7 +1196,7 @@
 [submodule "skins/Citizen"]
 	path = skins/Citizen
 	url = https://github.com/StarCitizenTools/mediawiki-skins-Citizen.git
-	branch = master
+	branch = main
 	ignore = dirty
 [submodule "extensions/Mermaid"]
 	path = extensions/Mermaid


### PR DESCRIPTION
Citizen has changed its default branch from master to main.