### PR TITLE
Remove 404.php from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ sftp-config.json
 /maintenance/dev/data
 /LocalSettings.php
 /includes/PlatformSettings.php
-/404.php
 
 # Building & testing
 npm-debug.log


### PR DESCRIPTION
No longer necessary. 404.php is no longer stored in w/ directory.