### PR TITLE
Remove duplicate `$wgIncludejQueryMigrate`

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -4463,17 +4463,6 @@ $wgIncludeLegacyJavaScript = false;
 $wgIncludejQueryMigrate = false;
 
 /**
- * Whether to load the jquery.migrate library.
- *
- * This provides jQuery 1.12 features that were removed in jQuery 3.0.
- * See also <https://jquery.com/upgrade-guide/3.0/> and
- * <https://phabricator.wikimedia.org/T280944>.
- *
- * @deprecated since 1.36
- */
-$wgIncludejQueryMigrate = true;
-
-/**
  * ResourceLoader will not generate URLs whose query string is more than
  * this many characters long, and will instead use multiple requests with
  * shorter query strings. Using multiple requests may degrade performance,


### PR DESCRIPTION
This has never been present like this upstream. I do not know why this is here, but this means it's being set to true again, and it shouldn't as with 1.38 it is removed so wikis need to prepare beforehand.