### PR TITLE
Labeler: run only when the actor is dependabot

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -5,13 +5,13 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
     - uses: actions/checkout@v2
       with:
         ref: 'REL1_37'
 
-    - if: ${{ github.actor == 'dependabot[bot]' }}
-      run: |
+    - run: |
         submodule=$(echo $(echo ${GITHUB_HEAD_REF} | cut -d'/' -f4,5 ) | cut -d'-' -f1 )
         git submodule update --init $submodule
         git pull https://github.com/${GITHUB_REPOSITORY} ${GITHUB_HEAD_REF}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         ref: 'REL1_37'
 
-    - if: github.actor == 'dependabot'
+    - if: ${{ github.actor == 'dependabot[bot]' }}
       run: |
         submodule=$(echo $(echo ${GITHUB_HEAD_REF} | cut -d'/' -f4,5 ) | cut -d'-' -f1 )
         git submodule update --init $submodule

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,8 @@ jobs:
       with:
         ref: 'REL1_37'
 
-    - run: |
+    - if: github.actor == 'dependabot'
+      run: |
         submodule=$(echo $(echo ${GITHUB_HEAD_REF} | cut -d'/' -f4,5 ) | cut -d'-' -f1 )
         git submodule update --init $submodule
         git pull https://github.com/${GITHUB_REPOSITORY} ${GITHUB_HEAD_REF}


### PR DESCRIPTION
- [ ] Test on https://github.com/lens0021/mediawiki

https://github.com/miraheze/mediawiki/pull/5022#issuecomment-1016116945: 
> Due to the way I created the labeler workflow, which automatically labels dependabot PRs depending on what changes the submodules have, it doesn't work for non-dependabot PRs due to branch names differing. I plan to fix eventually but it failing is fine for this. Apologies for the confusion and thanks for the PR!

