### PR TITLE
Temp disable automatic updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,1 @@
-version: 2
-updates:
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  labels: []
-  schedule:
-    interval: weekly
-    time: "00:00"
-  open-pull-requests-limit: 250
-  target-branch: REL1_37
+


### PR DESCRIPTION
In preparation for the mediawiki branch cut work, no automated updates will take place next week.