### PR TITLE
CdnCacheUpdate: remove http hack

### DIFF
--- a/includes/deferred/CdnCacheUpdate.php
+++ b/includes/deferred/CdnCacheUpdate.php
@@ -311,16 +311,9 @@ class CdnCacheUpdate implements DeferrableUpdate, MergeableUpdate {
 				$urlHost = strlen( $urlInfo['port'] ?? null )
 					? IP::combineHostAndPort( $urlInfo['host'], $urlInfo['port'] )
 					: $urlInfo['host'];
-				/**
-				 * Voidwalker hack start (force http scheme)
-				 * Varnish does not understand attempted https connections, causing purge requests going through https to fail.
-				 * See also phabricator.miraheze.org/T7441 and phabricator.wikimedia.org/T285504
-				 */
-				$urlInfo['scheme'] = 'http';
 				$baseReq = [
 					'method' => 'PURGE',		
-					'url' => wfAssembleUrl( $urlInfo ),
-					// Voidwalker hack end
+					'url' => $url,
 					'headers' => [
 						'Host' => $urlHost,
 						'Connection' => 'Keep-Alive',


### PR DESCRIPTION
Tracing:
* $url -> wfExpandUrl( $url, PROTO_INTERNAL )
* wfExpandUrl() -> $defaultProto = PROTO_INTERNAL -> $wgInternalServer !== false -> $serverUrl = $wgInternalServer
* $wgInternalServer -> str_replace( 'https://', 'http://', $wgServer ) -> http://\<server\>
* wfExpandUrl() -> wfParseUrl( $serverUrl ) -> $url = $serverUrl = $wgInternalServer -> $bits = parse_url( $url ) -> $bits['scheme'] = 'http' -> wfAssembleUrl( $bits ) OR just $url

All that means it should always be http anyway. Removing a hack means less having to maintain it later