### PR TITLE
Use InnoDB for search index

### DIFF
--- a/maintenance/tables-generated.sql
+++ b/maintenance/tables-generated.sql
@@ -879,7 +879,7 @@ CREATE TABLE /*_*/searchindex (
   si_text MEDIUMTEXT NOT NULL,
   FULLTEXT INDEX si_title (si_title),
   FULLTEXT INDEX si_text (si_text),
-	PRIMARY KEY(si_page)
+  PRIMARY KEY(si_page)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 

--- a/maintenance/tables-generated.sql
+++ b/maintenance/tables-generated.sql
@@ -874,13 +874,12 @@ CREATE TABLE /*_*/revision (
 
 
 CREATE TABLE /*_*/searchindex (
-  si_page INT UNSIGNED NOT NULL,
-  si_title VARCHAR(255) DEFAULT '' NOT NULL,
+  si_page int unsigned NOT NULL PRIMARY KEY,
+  si_title tinytext NOT NULL,
   si_text MEDIUMTEXT NOT NULL,
-  UNIQUE INDEX si_page (si_page),
   FULLTEXT INDEX si_title (si_title),
   FULLTEXT INDEX si_text (si_text)
-) ENGINE = MyISAM DEFAULT CHARSET = utf8;
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 
 CREATE TABLE /*_*/linktarget (

--- a/maintenance/tables-generated.sql
+++ b/maintenance/tables-generated.sql
@@ -874,11 +874,12 @@ CREATE TABLE /*_*/revision (
 
 
 CREATE TABLE /*_*/searchindex (
-  si_page INT UNSIGNED NOT NULL PRIMARY KEY,
+  si_page INT UNSIGNED NOT NULL,
   si_title TINYTEXT NOT NULL,
   si_text MEDIUMTEXT NOT NULL,
   FULLTEXT INDEX si_title (si_title),
-  FULLTEXT INDEX si_text (si_text)
+  FULLTEXT INDEX si_text (si_text),
+	PRIMARY KEY(si_page)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 

--- a/maintenance/tables-generated.sql
+++ b/maintenance/tables-generated.sql
@@ -874,8 +874,8 @@ CREATE TABLE /*_*/revision (
 
 
 CREATE TABLE /*_*/searchindex (
-  si_page int unsigned NOT NULL PRIMARY KEY,
-  si_title tinytext NOT NULL,
+  si_page INT UNSIGNED NOT NULL PRIMARY KEY,
+  si_title TINYTEXT NOT NULL,
   si_text MEDIUMTEXT NOT NULL,
   FULLTEXT INDEX si_title (si_title),
   FULLTEXT INDEX si_text (si_text)

--- a/maintenance/tables.json
+++ b/maintenance/tables.json
@@ -3658,7 +3658,7 @@
 				]
 			}
 		],
-		"pk": [ "si_page" ]
+		"pk": [ "si_page" ],
 		"table_options": [
 			"ENGINE=InnoDB",
 			"DEFAULT CHARSET=utf8mb4"

--- a/maintenance/tables.json
+++ b/maintenance/tables.json
@@ -3630,8 +3630,8 @@
 			{
 				"name": "si_title",
 				"comment": "Munged version of title",
-				"type": "string",
-				"options": { "length": 255, "notnull": true, "default": "" }
+				"type": "text",
+				"options": { "length": 255, "notnull": true }
 			},
 			{
 				"name": "si_text",
@@ -3641,11 +3641,6 @@
 			}
 		],
 		"indexes": [
-			{
-				"name": "si_page",
-				"columns": [ "si_page" ],
-				"unique": true
-			},
 			{
 				"name": "si_title",
 				"columns": [ "si_title" ],
@@ -3663,10 +3658,10 @@
 				]
 			}
 		],
-		"pk": [],
+		"pk": [ "si_page" ]
 		"table_options": [
-			"ENGINE=MyISAM",
-			"DEFAULT CHARSET=utf8"
+			"ENGINE=InnoDB",
+			"DEFAULT CHARSET=utf8mb4"
 		]
 	},
 	{


### PR DESCRIPTION
From https://gerrit.wikimedia.org/r/c/mediawiki/core/+/519324/

We used to have it so searchindex used innodb but somehow lost that.